### PR TITLE
chore(mysql_db): Ansible 2.10 compatibility for mysql_db

### DIFF
--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -6,7 +6,7 @@
     state: absent
 
 - name: Create a new database with name '{{ roundcube_sql_database }}'
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ roundcube_sql_database }}"
 
 - name: Create mariadb user


### PR DESCRIPTION
Since Ansible 2.10, `mysql_db` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.mysql`. Note that this change probably breaks compatibility with Ansible <= 2.8.